### PR TITLE
Exchange fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,18 +15,18 @@ Apache Maven
 	<dependency>
 		<groupId>io.hoplin</groupId>
 		<artifactId>hoplin-client</artifactId>
-		<version>1.1.3</version>
+		<version>1.1.4-SNAPSHOT</version>
 	</dependency>
 ```
 
 Gradle Groovy DSL
 ```java
-implementation 'io.hoplin:hoplin-client:1.1.3'
+implementation 'io.hoplin:hoplin-client:1.1.4-SNAPSHOT'
 ```
 
 Gradle Kotlin DSL
 ```java
-implementation("io.hoplin:hoplin-client:1.1.3")
+implementation("io.hoplin:hoplin-client:1.1.4-SNAPSHOT")
 ```
 Download directly from Maven Central
 ```

--- a/README.md
+++ b/README.md
@@ -639,6 +639,14 @@ public class LogDetail {
 }
 ```
 
+Publishing a message without envelope. For `Consumer<MessageConfiguration>` `setNativeMessageFormat(true)`.
+```java
+// configuring publish without envelope
+ExchangeClient client = clientFromExchange();
+LogDetail detail = getLogDetail();
+client.publish(detail, cfg -> cfg.setNativeMessageFormat(true));
+```
+
 ## Closing clients
 Client can be closed couple ways.
 First by calling `close` method on the client itself.

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -57,7 +57,7 @@
   <parent>
     <artifactId>hoplin-parent</artifactId>
     <groupId>io.hoplin</groupId>
-    <version>1.1.3</version>
+    <version>1.1.4-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/client/src/main/java/io/hoplin/AbstractExchangeClient.java
+++ b/client/src/main/java/io/hoplin/AbstractExchangeClient.java
@@ -357,7 +357,7 @@ abstract class AbstractExchangeClient implements ExchangeClient {
     // Wrap our message original message
     final MessagePayload<T> payload = new MessagePayload<>(message);
     payload.setType(message.getClass());
-    client.basicPublish(binding.getExchange(), "", payload);
+    client.basicPublish(binding.getExchange(), routingKey, payload);
 
     return promise;
   }

--- a/client/src/main/java/io/hoplin/AbstractExchangeClient.java
+++ b/client/src/main/java/io/hoplin/AbstractExchangeClient.java
@@ -310,11 +310,8 @@ abstract class AbstractExchangeClient implements ExchangeClient {
 
     // populate our configurations with default etc...
     final MessageConfiguration conf = new MessageConfiguration();
-    final Consumer<MessageConfiguration> composite = cfg.andThen(after -> {
-      after.setNativeMessageFormat(true);
-    });
 
-    composite.accept(conf);
+    cfg.accept(conf);
     Object val;
 
     if (conf.isNativeMessageFormat()) {

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -23,7 +23,7 @@
       <artifactId>hoplin-client</artifactId>
       <groupId>io.hoplin</groupId>
       <scope>compile</scope>
-      <version>1.1.3</version>
+      <version>1.1.4-SNAPSHOT</version>
     </dependency>
 
     <dependency>
@@ -45,7 +45,7 @@
   <parent>
     <artifactId>hoplin-parent</artifactId>
     <groupId>io.hoplin</groupId>
-    <version>1.1.3</version>
+    <version>1.1.4-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/logreader/pom.xml
+++ b/logreader/pom.xml
@@ -22,7 +22,7 @@
       <artifactId>hoplin-client</artifactId>
       <groupId>io.hoplin</groupId>
       <scope>compile</scope>
-      <version>1.1.3</version>
+      <version>1.1.4-SNAPSHOT</version>
     </dependency>
 
     <dependency>
@@ -58,7 +58,7 @@
   <parent>
     <artifactId>hoplin-parent</artifactId>
     <groupId>io.hoplin</groupId>
-    <version>1.1.3</version>
+    <version>1.1.4-SNAPSHOT</version>
   </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -325,6 +325,6 @@
 
   <url>http://hoplin.io</url>
 
-  <version>1.1.3</version>
+  <version>1.1.4-SNAPSHOT</version>
 
 </project>

--- a/toolbox/pom.xml
+++ b/toolbox/pom.xml
@@ -34,7 +34,7 @@
   <parent>
     <artifactId>hoplin-parent</artifactId>
     <groupId>io.hoplin</groupId>
-    <version>1.1.3</version>
+    <version>1.1.4-SNAPSHOT</version>
   </parent>
 
 


### PR DESCRIPTION
Added the following: 
  - fix for publish setNativeMessageFormat defaulting to true
  - fix for publishAsync overriding routing key
  - documentation example for message without envelope
